### PR TITLE
Fix ability registration

### DIFF
--- a/Gdtklib/AbilitySystem/lib/AbilitySystem.gd
+++ b/Gdtklib/AbilitySystem/lib/AbilitySystem.gd
@@ -9,7 +9,7 @@ var attribute_set: AbilityAttributeSet = null
 func _ready():
 	for c in get_children():
 		if c is Ability:
-			ability_list[c.name].append(c)
+			ability_list[c.name] = c
 		elif c is AbilityAttributeSet:
 			attribute_set = c
 	pass # Replace with function body.


### PR DESCRIPTION
## Summary
- map ability names directly to their nodes

## Testing
- `godot` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7b949f288327b232df9744163bca